### PR TITLE
Prevent Ratelimit during command registration

### DIFF
--- a/src/struct/Core.ts
+++ b/src/struct/Core.ts
@@ -84,7 +84,7 @@ export class Core extends Client {
 			
 			// Discord limits descriptions to 100 characters
 			if (body.description.length > 100) {
-				body.description = body.substring(0, 95) + '...';
+				body.description = body.description.substring(0, 95) + '...';
 			}
 			// Add it to our list
 			cmdList.push(body);

--- a/src/struct/Core.ts
+++ b/src/struct/Core.ts
@@ -71,6 +71,7 @@ export class Core extends Client {
 
 	private async commandHandler(): Promise<void> {
 		const files = readdirSync(resolve(__dirname, "..", "commands"));
+		const cmdList = [];
 		for (const file of files) {
 			const command = (
 				await import(resolve(__dirname, "..", "commands", file))
@@ -80,14 +81,22 @@ export class Core extends Client {
 				description: command.description,
 				options: command.options,
 			};
-			await makeAPIRequest(
-				`/applications/${CONFIG.CLIENT_ID}/commands`,
-				"POST",
-				body,
-			);
+			
+			// Discord limits descriptions to 100 characters
+			if (body.description.length > 100) {
+				body.description = body.substring(0, 95) + '...';
+			}
+			// Add it to our list
+			cmdList.push(body);
 			this.commands.set(command.name, command);
 			pogger.success(`Command loaded: ${command.name}`);
 		}
+		// Use one global request to update all commands.
+		await makeAPIRequest(
+			`/applications/${CONFIG.CLIENT_ID}/commands`,
+			"PUT",
+			JSON.stringify(cmdList),
+		);
 	}
 
 	private async eventHandler() {

--- a/src/utils/makeAPIRequest.ts
+++ b/src/utils/makeAPIRequest.ts
@@ -5,12 +5,12 @@ import { CONFIG } from "../config";
 export async function makeAPIRequest(
 	path: string,
 	method: string,
-	body: LooseObject,
+	body: LooseObject | string,
 ): Promise<any> {
 	return new Promise((resolve, reject) => {
 		fetch(`${CONFIG.API_URL}${path}`, {
 			method,
-			body: JSON.stringify(body),
+			body: typeof body === 'string' ? body : JSON.stringify(body),
 			headers: {
 				Authorization: `Bot ${CONFIG.TOKEN}`,
 				"Content-Type": "application/json",


### PR DESCRIPTION
When registering commands individually the command registration rate limit is hit. This can be avoided by using the bulk command endpoint instead, or by offsetting command registration. I opted for this endpoint instead to snip any loose commands and update them all at once.

Similarly an error was encountered when attempting to register the setmessage command as discord now limits command descriptions to 100 characters.